### PR TITLE
scripts make sure they can access docker-compose from whereever they are called

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,28 @@ You should be able to use the console to run queries such as:
   }
 }``
 
+## Bundled Scripts
+
+This application comes bundled with some useful scripts in the `/scripts` directory. As much as possible, these should
+be used to perform commands as they will also deal with spinning up and down the requried containers.
+
+A brief description of each:
+
+`build-php.sh` - Rebuilds any containers that use PHP. Useful if you change php settings in `.env`
+`reload-nginx.sh` - Reload Nginx in the Nginx container. Use this is you have altered Nginx config
+`run-tests.sh` - Runs all phpunit tests for the associated application
+`ssh-nginx.sh` - SSH to the nginx container
+`ssh-workspace.sh` - SSH to the Workspace container
+`start.sh` - Starts only the containers needed to run the app. Will not start workspace or test containers
+`start-test-containers.sh` - Starts the containers needed for running tests
+`start-workspace.sh` - Starts only the workspace and related containers
+`stop-test-containers.sh` - Stops all test containers
+`stop-workspace.sh` - Stops the workspace container 
+`up-with-rebuild.sh` - Spins rebuilds and starts the core containers 
+`update-conversations.sh` - Makes sure the right containers are running and installs the newest OD conversations
+`update-opendialog.sh` - Installs the latest composer and node requirements on the project as well as the webchat component
+`update-webchat-settings.sh` - Updates the webchat settings based on the artisan command
+
 ## Automated testing
 
 To run automated tests with PHPUnit first ensure that phpunit.xml has the correct information for connecting to Dgraph.
@@ -101,9 +123,13 @@ To run automated tests with PHPUnit first ensure that phpunit.xml has the correc
 <env name="DGRAPH_PORT" value="8082"/>
 `
 
-You can then run `phpunit`
+Test suites run against 2 test DGraph containers `dgraph-zero-test` and `dgraph-server-test` and these must be running
+before you can run tests. Keep in mind that this is a separate Dgraph instance, so it will not be changing any data that
+the application itself is using.  
 
-Keep in mind that this uses a separate Dgraph instance so it will not be changing any data that the application itself is using.  
+You can spin up the required containers, run the tests and then spin them down again by running
+
+        bash scripts/run-tests.sh
 
 ## Setting up xDebug
 

--- a/scripts/build-php.sh
+++ b/scripts/build-php.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd ${DIR}/..
+
 echo "### Rebuilding containers that use PHP ###"
 docker-compose build workspace php-fpm php-worker
 

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd ${DIR}/..
+
+bash ${DIR}/start-test-containers.sh
+
+echo "### Running Test suite ###"
+
+docker-compose exec workspace php vendor/phpunit/phpunit/phpunit
+
+bash ${DIR}/stop-test-containers.sh

--- a/scripts/ssh-nginx.sh
+++ b/scripts/ssh-nginx.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd ${DIR}/..
+
 echo "### SSH to nginx ###"
 docker-compose up -d nginx
 docker-compose exec nginx bash

--- a/scripts/ssh-workspace.sh
+++ b/scripts/ssh-workspace.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd ${DIR}/..
+
 echo "### Staring only the required containers ###"
 docker-compose up -d workspace
 docker-compose exec workspace bash

--- a/scripts/start-test-containers.sh
+++ b/scripts/start-test-containers.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd ${DIR}/..
+
+echo "### Starting test containers ###"
+docker-compose up -d workspace dgraph-zero-test dgraph-server-test

--- a/scripts/start-workspace.sh
+++ b/scripts/start-workspace.sh
@@ -2,6 +2,5 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd ${DIR}/..
 
-echo "### Reloading NGINX ###"
-docker-compose up -d nginx
-docker-compose exec nginx nginx -s reload
+echo "### Starting Workspace ###"
+docker-compose up -d workspace

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,3 +1,6 @@
 #!/usr/bin/env bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd ${DIR}/..
+
 echo "### Starting required containers ###"
 docker-compose up -d php-fpm mysql nginx dgraph-zero dgraph-server memcached

--- a/scripts/stop-test-containers.sh
+++ b/scripts/stop-test-containers.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd ${DIR}/..
+
+echo "### Stopping test containers ###"
+docker-compose stop workspace dgraph-zero-test dgraph-server-test workspace

--- a/scripts/stop-workspace.sh
+++ b/scripts/stop-workspace.sh
@@ -1,3 +1,6 @@
 #!/usr/bin/env bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd ${DIR}/..
+
 echo "### Stopping Workspace ###"
 docker-compose stop workspace docker-in-docker

--- a/scripts/up-with-rebuild.sh
+++ b/scripts/up-with-rebuild.sh
@@ -1,3 +1,6 @@
 #!/usr/bin/env bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd ${DIR}/..
+
 echo "### Recreating required containers ###"
 docker-compose up --force-recreate -d php-fpm mysql nginx dgraph-zero dgraph-server memcached

--- a/scripts/update-conversations.sh
+++ b/scripts/update-conversations.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd ${DIR}/..
+
 echo "### Using workspace to update OpenDialog Conversations ###"
 docker-compose up -d workspace dgraph-server dgraph-zero mysql
 
 echo "### Updating webchat conversations ###"
-docker-compose exec workspace bash -c "php artisan conversations:setup"
+docker-compose exec workspace bash -c "php artisan conversations:setup --non-interactive"
 
 bash scripts/stop-workspace.sh

--- a/scripts/update-opendialog.sh
+++ b/scripts/update-opendialog.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd ${DIR}/..
+
 echo "### Using workspace to update BDO OpenDialog ###"
 docker-compose up -d workspace
 

--- a/scripts/update-webchat-settings.sh
+++ b/scripts/update-webchat-settings.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd ${DIR}/..
+
 echo "### Using workspace to update OD Conversations ###"
 docker-compose up -d workspace dgraph-server dgraph-zero mysql
 


### PR DESCRIPTION
The scripts can now be called from anywhere and still access the docker-compose file

Readme is updated with script info and how to run tests