### PR TITLE
Sets the default postgres version to 12

### DIFF
--- a/env.example
+++ b/env.example
@@ -300,7 +300,7 @@ MARIADB_ENTRYPOINT_INITDB=./mariadb/docker-entrypoint-initdb.d
 
 ### POSTGRES ##############################################
 
-POSTGRES_VERSION=alpine
+POSTGRES_VERSION=12
 POSTGRES_DB=default
 POSTGRES_USER=default
 POSTGRES_PASSWORD=secret


### PR DESCRIPTION
Since the OD app has been tested as working with Postgres version 12, this PR sets this as the default value.