### PR TITLE
Fix to Workspace Dockerfile get XDebug working

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -351,7 +351,7 @@ ARG INSTALL_XDEBUG=false
 
 RUN if [ ${INSTALL_XDEBUG} = true ]; then \
     # Load the xdebug extension only with phpunit commands
-    apt-get install -y php${LARADOCK_PHP_VERSION}-xdebug && \
+    apt-get update && apt-get install -y php${LARADOCK_PHP_VERSION}-xdebug && \
     sed -i 's/^;//g' /etc/php/${LARADOCK_PHP_VERSION}/cli/conf.d/20-xdebug.ini \
 ;fi
 


### PR DESCRIPTION
This PR fixes an issue which stops XDebug from working. After setting the relevant environment variables to enable XDebug and running `docker-compose build`, an error would occur when trying to install XDebug. It seems the fix is to update the package index just prior to attempting to install it.