### PR TITLE
Expose port 6006 on workspace

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,6 +100,7 @@ services:
         - "dockerhost:${DOCKER_HOST_IP}"
       ports:
         - "${WORKSPACE_SSH_PORT}:22"
+        - "6006:6006"
       tty: true
       environment:
         - PHP_IDE_CONFIG=${PHP_IDE_CONFIG}


### PR DESCRIPTION
Exposes port 6006 so that `yarn storybook:serve` can be run from with in the workspace container and used on the parent machine