### PR TITLE
Updates to support DGRAPH v20.11.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -311,7 +311,7 @@ services:
         - 8080:8080
         - 9080:9080
       restart: on-failure
-      command: dgraph alpha --my=dgraph-server:7080 --lru_mb=2048 --zero=dgraph-zero:5080
+      command: dgraph alpha --auth_token=${DGRAPH_AUTH_TOKEN} --whitelist 0.0.0.0/0 --my=dgraph-server:7080 --lru_mb=2048 --zero=dgraph-zero:5080
       networks:
         - backend
 
@@ -326,7 +326,7 @@ services:
 
     dgraph-server-test:
       image: dgraph/dgraph:${DGRAPH_VERSION}
-      command: dgraph alpha --my=dgraph-server-test:7082 --lru_mb=2048 --zero=dgraph-zero-test:5082 -o=2
+      command: dgraph alpha --auth_token=dgraphtestservertoken --whitelist 0.0.0.0/0 --my=dgraph-server-test:7082 --lru_mb=2048 --zero=dgraph-zero-test:5082 -o=2
       networks:
         - backend
 

--- a/env.example
+++ b/env.example
@@ -6,7 +6,7 @@
 
 CHOSEN_DATABASE=mysql
 
-DGRAPH_VERSION=v1.2.5
+DGRAPH_VERSION=v20.11.0
 DGRAPH_AUTH_TOKEN=dgraphauthsecrettoken
 
 ### Paths #################################################

--- a/env.example
+++ b/env.example
@@ -7,6 +7,7 @@
 CHOSEN_DATABASE=mysql
 
 DGRAPH_VERSION=v1.2.5
+DGRAPH_AUTH_TOKEN=dgraphauthsecrettoken
 
 ### Paths #################################################
 


### PR DESCRIPTION
Adds  `--whitelist 0.0.0.0/0` and `--auth_token=<token>` options to the dgraph docker containers, as well as a `DGRAPH_AUTH_TOKEN` env var to the `.env.example` file. 
These changes are necessary to support local development for opendialog app and core with upgraded dgraph support:
* Core: https://github.com/opendialogai/core/pull/437
* App: https://github.com/opendialogai/opendialog/pull/240/files