### PR TITLE
XDebug 3 support

### DIFF
--- a/php-fpm/xdebug.ini
+++ b/php-fpm/xdebug.ini
@@ -1,18 +1,14 @@
 ; NOTE: The actual debug.so extention is NOT SET HERE but rather (/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini)
 
-xdebug.remote_host="host.docker.internal"
-xdebug.remote_connect_back=0
+xdebug.client_host="host.docker.internal"
 xdebug.remote_port=9000
 xdebug.idekey=PHPSTORM
 
-xdebug.remote_autostart=1
-xdebug.remote_enable=1
+xdebug.mode=debug,coverage
+xdebug.start_with_request=1
 xdebug.cli_color=0
-xdebug.profiler_enable=0
-xdebug.profiler_output_dir="~/xdebug/phpstorm/tmp/profiling"
 
 xdebug.remote_handler=dbgp
-xdebug.remote_mode=req
 
 xdebug.var_display_max_children=-1
 xdebug.var_display_max_data=-1

--- a/workspace/xdebug.ini
+++ b/workspace/xdebug.ini
@@ -1,18 +1,14 @@
 ; NOTE: The actual debug.so extention is NOT SET HERE but rather (/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini)
 
-xdebug.remote_host="host.docker.internal"
-xdebug.remote_connect_back=0
+xdebug.client_host="host.docker.internal"
 xdebug.remote_port=9000
 xdebug.idekey=PHPSTORM
 
-xdebug.remote_autostart=1
-xdebug.remote_enable=1
+xdebug.mode=debug,coverage
+xdebug.start_with_request=1
 xdebug.cli_color=0
-xdebug.profiler_enable=0
-xdebug.profiler_output_dir="~/xdebug/phpstorm/tmp/profiling"
 
 xdebug.remote_handler=dbgp
-xdebug.remote_mode=req
 
 xdebug.var_display_max_children=-1
 xdebug.var_display_max_data=-1


### PR DESCRIPTION
This PR updates `php.ini` files to support [XDebug 3](https://xdebug.org/docs/upgrade_guide). If you are unsure on your XDebug version, run `./php-fpm/xdebug status` to confirm it. If you are still on version 2 you'll need to run `docker-compose build` to rebuild the images, which will update XDebug in turn.

For reference the following are screenshots of my working PhpStorm configuration:

| Interpreter | Server | Debug |
| --- | --- | --- |
| ![Screenshot 2021-02-18 at 10 50 20](https://user-images.githubusercontent.com/6834105/108346720-99f7e700-71d7-11eb-8d0e-8ee6d9764957.png) | ![Screenshot 2021-02-18 at 10 50 10](https://user-images.githubusercontent.com/6834105/108346744-a0865e80-71d7-11eb-9903-f21d04b6d14c.png) | ![Screenshot 2021-02-18 at 10 50 03](https://user-images.githubusercontent.com/6834105/108346770-a67c3f80-71d7-11eb-91f7-b77728a274d7.png) |


