### PR TITLE
DGraph 21.03.0 Upgrade

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -312,7 +312,7 @@ services:
         - 8080:8080
         - 9080:9080
       restart: on-failure
-      command: dgraph alpha --security token=${DGRAPH_AUTH_TOKEN} --security whitelist=0.0.0.0/0 --my=dgraph-server:7080 --lru_mb=2048 --zero=dgraph-zero:5080
+      command: dgraph alpha --security token=${DGRAPH_AUTH_TOKEN} --security whitelist=0.0.0.0/0 --my=dgraph-server:7080 --zero=dgraph-zero:5080
       networks:
         - backend
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -312,14 +312,14 @@ services:
         - 8080:8080
         - 9080:9080
       restart: on-failure
-      command: dgraph alpha --auth_token=${DGRAPH_AUTH_TOKEN} --whitelist 0.0.0.0/0 --my=dgraph-server:7080 --lru_mb=2048 --zero=dgraph-zero:5080
+      command: dgraph alpha --security token=${DGRAPH_AUTH_TOKEN} --security whitelist=0.0.0.0/0 --my=dgraph-server:7080 --lru_mb=2048 --zero=dgraph-zero:5080
       networks:
         - backend
 
   ### Dgraph used for testing ################################################
     dgraph-zero-test:
       image: dgraph/dgraph:${DGRAPH_VERSION}
-      command: dgraph zero --my=dgraph-zero-test:5082 -o=2
+      command: dgraph zero --my=dgraph-zero-test:5082
       links:
         - dgraph-server
       networks:
@@ -327,15 +327,6 @@ services:
 
     dgraph-server-test:
       image: dgraph/dgraph:${DGRAPH_VERSION}
-      command: dgraph alpha --auth_token=dgraphtestservertoken --whitelist 0.0.0.0/0 --my=dgraph-server-test:7082 --lru_mb=2048 --zero=dgraph-zero-test:5082 -o=2
-      networks:
-        - backend
-
-  ### Dgraph UI to inspect Dgraph data ################################################
-    ratel:
-      image: dgraph/dgraph:${DGRAPH_VERSION}
-      ports:
-        - 9001:8000
-      command: dgraph-ratel
+      command: dgraph alpha --security token=dgraphtestservertoken --security whitelist=0.0.0.0/0 --my=dgraph-server-test:7082 --zero=dgraph-zero-test:5082
       networks:
         - backend

--- a/env.example
+++ b/env.example
@@ -6,7 +6,7 @@
 
 CHOSEN_DATABASE=mysql
 
-DGRAPH_VERSION=v20.11.0
+DGRAPH_VERSION=v21.03.0
 DGRAPH_AUTH_TOKEN=dgraphauthsecrettoken
 
 ### Paths #################################################


### PR DESCRIPTION
This pull request updates the development environment to use DGraph 21.03.0 by default.

The changes are primarily related to bumping the version and updating the commands used to start DGraph as the security options and the lru option have changed format 