### PR TITLE
Security flags correctly described

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -319,7 +319,7 @@ services:
   ### Dgraph used for testing ################################################
     dgraph-zero-test:
       image: dgraph/dgraph:${DGRAPH_VERSION}
-      command: dgraph zero --my=dgraph-zero-test:5082 -o 2
+      command: dgraph zero --my=dgraph-zero-test:5082 -o=2
       links:
         - dgraph-server-test
       networks:
@@ -327,6 +327,6 @@ services:
 
     dgraph-server-test:
       image: dgraph/dgraph:${DGRAPH_VERSION}
-      command: dgraph alpha --security token=dgraphtestservertoken;whitelist=0.0.0.0/0 --my=dgraph-server-test:7082 --zero=dgraph-zero-test:5082 -o 2
+      command: dgraph alpha --security token=dgraphtestservertoken;whitelist=0.0.0.0/0 --my=dgraph-server-test:7082 --zero=dgraph-zero-test:5082 -o=2
       networks:
         - backend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -312,21 +312,21 @@ services:
         - 8080:8080
         - 9080:9080
       restart: on-failure
-      command: dgraph alpha --security token=${DGRAPH_AUTH_TOKEN} --security whitelist=0.0.0.0/0 --my=dgraph-server:7080 --zero=dgraph-zero:5080
+      command: dgraph alpha --security token=${DGRAPH_AUTH_TOKEN};whitelist=0.0.0.0/0 --my=dgraph-server:7080 --zero=dgraph-zero:5080
       networks:
         - backend
 
   ### Dgraph used for testing ################################################
     dgraph-zero-test:
       image: dgraph/dgraph:${DGRAPH_VERSION}
-      command: dgraph zero --my=dgraph-zero-test:5082 -o=2
+      command: dgraph zero --my=dgraph-zero-test:5082 -o 2
       links:
-        - dgraph-server
+        - dgraph-server-test
       networks:
         - backend
 
     dgraph-server-test:
       image: dgraph/dgraph:${DGRAPH_VERSION}
-      command: dgraph alpha --security token=dgraphtestservertoken --security whitelist=0.0.0.0/0 --my=dgraph-server-test:7082 --zero=dgraph-zero-test:5082 -o=2
+      command: dgraph alpha --security token=dgraphtestservertoken;whitelist=0.0.0.0/0 --my=dgraph-server-test:7082 --zero=dgraph-zero-test:5082 -o 2
       networks:
         - backend


### PR DESCRIPTION
This PR sets the security flag correctly by delimiting token and whitelist with a semicolon