### PR TITLE
Default DGraph version bump

### DIFF
--- a/env.example
+++ b/env.example
@@ -6,7 +6,7 @@
 
 CHOSEN_DATABASE=mysql
 
-DGRAPH_VERSION=v21.03.0
+DGRAPH_VERSION=v21.03.0-12-g44005bc82
 DGRAPH_AUTH_TOKEN=dgraphauthsecrettoken
 
 ### Paths #################################################


### PR DESCRIPTION
bumps defeault dgraph version (to v21.03.0-12-g44005bc82)  whilst waiting for this fix -> https://github.com/dgraph-io/dgraph/commit/00ada83527e0ef3c2d834fe1977b6ab3863ca5a0 to land on main tag