### PR TITLE
Re-arranging application set up steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ in `/var/www/opendialog`:
     * Use `dgraph-server` for the DGraph host
 * run `php artisan migrate` to setup tables
 * run `php artisan user:create` to create a user
+* run `php artisan schema:init` to setup the Dgraph schema
 * run `php artisan configurations:create` to create the default component configurations
 * run `php artisan webchat:setup` to setup default values for webchat
-* run `php artisan schema:init` to setup the Dgraph schema
 * run `yarn install` and `yarn run dev` to setup the admin interface
 
 


### PR DESCRIPTION
This PR rearranges the application set up steps defined in the README. Previously if you tried to run the configuration creation step before initialising the graph schema you'd get the following error:

`[{"message":"Unknown type \"UpdateConversationObjectInput\".","locations":[{"line":1,"column":5}]}]GraphQL response body contains errors.`