### PR TITLE
Fixing env.example for Docker Compose v2

### DIFF
--- a/env.example
+++ b/env.example
@@ -376,7 +376,7 @@ MAILDEV_SMTP_PORT=25
 VARNISH_CONFIG=/etc/varnish/default.vcl
 VARNISH_PORT=8080
 VARNISH_BACKEND_PORT=8888
-VARNISHD_PARAMS=-p default_ttl=3600 -p default_grace=3600
+VARNISHD_PARAMS="-p default_ttl=3600 -p default_grace=3600"
 
 ### Varnish ###############################################
 
@@ -540,7 +540,7 @@ FACE_DETECTOR_CASCADE_FILE=haarcascade_frontalface_alt.xml
 OPTIMIZERS=[]
 JPEGTRAN_PATH=/usr/bin/jpegtran
 PROGRESSIVE_JPEG=True
-FILTERS=["thumbor.filters.brightness", "thumbor.filters.contrast", "thumbor.filters.rgb", "thumbor.filters.round_corner", "thumbor.filters.quality", "thumbor.filters.noise", "thumbor.filters.watermark", "thumbor.filters.equalize", "thumbor.filters.fill", "thumbor.filters.sharpen", "thumbor.filters.strip_icc", "thumbor.filters.frame", "thumbor.filters.grayscale", "thumbor.filters.rotate", "thumbor.filters.format", "thumbor.filters.max_bytes", "thumbor.filters.convolution", "thumbor.filters.blur", "thumbor.filters.extract_focal", "thumbor.filters.no_upscale"]
+FILTERS=["thumbor.filters.brightness","thumbor.filters.contrast","thumbor.filters.rgb","thumbor.filters.round_corner","thumbor.filters.quality","thumbor.filters.noise","thumbor.filters.watermark","thumbor.filters.equalize","thumbor.filters.fill","thumbor.filters.sharpen","thumbor.filters.strip_icc","thumbor.filters.frame","thumbor.filters.grayscale","thumbor.filters.rotate","thumbor.filters.format","thumbor.filters.max_bytes","thumbor.filters.convolution","thumbor.filters.blur","thumbor.filters.extract_focal","thumbor.filters.no_upscale"]
 RESULT_STORAGE_EXPIRATION_SECONDS=0
 RESULT_STORAGE_FILE_STORAGE_ROOT_PATH=/data/result_storage
 RESULT_STORAGE_STORES_UNSAFE=False
@@ -692,14 +692,14 @@ MAILU_DMARC_RUF=admin
 # Welcome email, enable and set a topic and body if you wish to send welcome
 # emails to all users.
 MAILU_WELCOME=True
-MAILU_WELCOME_SUBJECT=Welcome to your new email account
-MAILU_WELCOME_BODY=Welcome to your new email account, if you can read this, then it is configured properly!
+MAILU_WELCOME_SUBJECT="Welcome to your new email account"
+MAILU_WELCOME_BODY="Welcome to your new email account, if you can read this, then it is configured properly!"
 # Path to the admin interface if enabled
 MAILU_WEB_ADMIN=/admin
 # Path to the webmail if enabled
 MAILU_WEB_WEBMAIL=/webmail
 # Website name
-MAILU_SITENAME=Example Mail
+MAILU_SITENAME="Example Mail"
 # Linked Website URL
 MAILU_WEBSITE=http://mail.example.com
 # Default password scheme used for newly created accounts and changed passwords
@@ -826,7 +826,7 @@ GEARMAN_MYSQL_PORT=3306
 # Mysql server user (Default: root)
 GEARMAN_MYSQL_USER=root
 # Mysql password
-GEARMAN_MYSQL_PASSWORD=	
+GEARMAN_MYSQL_PASSWORD=
 # Path to file with mysql password(Docker secrets)
 GEARMAN_MYSQL_PASSWORD_FILE=
 # Database to use by Gearman (Default: Gearmand)


### PR DESCRIPTION
This PR fixes the `env.example` file so that it could parsed by Docker Compose V2. It seems this is a problem others experienced too (see https://github.com/docker/compose/issues/8763), this PR is simply a workaround of this issue.

The issue presents itself when you try to run `docker compose up`, and you'll receive an error like "unexpected character "-" in variable name..." If you're experiencing this, it means you need to make the changes below your `.env` file.