### PR TITLE
Adds Redis to the dev-env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ volumes:
     driver: ${VOLUMES_DRIVER}
   dgraph:
     driver: ${VOLUMES_DRIVER}
+  redis:
+    driver: ${VOLUMES_DRIVER}
 
 services:
 
@@ -265,6 +267,16 @@ services:
         - POSTGRES_CONFLUENCE_DB=${CONFLUENCE_POSTGRES_DB}
         - POSTGRES_CONFLUENCE_USER=${CONFLUENCE_POSTGRES_USER}
         - POSTGRES_CONFLUENCE_PASSWORD=${CONFLUENCE_POSTGRES_PASSWORD}
+      networks:
+        - backend
+
+### Redis ################################################
+    redis:
+      build: ./redis
+      volumes:
+        - ${DATA_PATH_HOST}/redis:/data
+      ports:
+        - "${REDIS_PORT}:6379"
       networks:
         - backend
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -6,4 +6,4 @@ CHOSEN_DATABASE=$(grep CHOSEN_DATABASE .env | xargs)
 CHOSEN_DATABASE=${CHOSEN_DATABASE#*=}
 
 echo "### Starting required containers (db=${CHOSEN_DATABASE})###"
-docker-compose up -d php-fpm ${CHOSEN_DATABASE} nginx dgraph-zero dgraph-server memcached
+docker-compose up -d php-fpm ${CHOSEN_DATABASE} nginx dgraph-zero dgraph-server redis


### PR DESCRIPTION
This PR adds a Redis container to the docker-compose file and updates the `start.sh` script to start it rather than memcached. 

This is useful when wanting to use query caching as it is a cache driver that supports tags.